### PR TITLE
Add ability to work without `begin`. 

### DIFF
--- a/src/Chain.jl
+++ b/src/Chain.jl
@@ -170,10 +170,6 @@ to a function call with the previous result as the only argument.
 If there are no underscores and the argument is a function call or a macrocall,
 the call has the previous result prepended as the first argument.
 
-When using this form of `@chain`, without a `begin` block, you cannot use infix
-operators, binary operators, or anonymous functions. For example, `@chain 1 (_ + 2)`
-will fail.
-
 Example:
 
 ```

--- a/src/Chain.jl
+++ b/src/Chain.jl
@@ -152,6 +152,9 @@ x == sum(sqrt.(filter(!=(2), [1, 2, 3])))
 ```
 """
 macro chain(initial_value, block::Expr)
+    if !(block.head == :block)
+        block = Expr(:block, block)
+    end
     rewrite_chain_block(initial_value, block)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,7 +64,7 @@ end
     @test y == 6
 
     f() = 1
-    y = @chain f() only
+    y = @chain f() first
     @test y == 1
 
     y = @chain x sum(_) max(0, _) first

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,24 +69,27 @@ end
 
     y = @chain x sum(_) max(0, _) first
     @test y == 6
+
+    y = @chain 1 (t -> t + 1)()
+    @test y == 2
+
+    y = @chain 1 (t -> t + 1)() first max(0, _)
+    @test y == 2
+
+    y = @chain 1 (==(2))
+    @test y == false
+
+    y = @chain 1 (==(2)) first (==(false))
+    @test y == 2
+
+    y = @chain 1 (_ + 1)
+    @test y == 2
+
+    y = @chain 1 (_ + 1) first max(0, _)
+    @test y == 2
 end
 
 @testset "invalid invocations" begin
-    # no begin with infix
-    @test_throws LoadError eval(quote
-        @chain 1 +(1)
-    end)
-
-    # no begin with anonymous function
-    @test_throws LoadError eval(quote
-        @chain 1 (t -> t + 1)()
-    end)
-
-    # no begin with sum
-    @test_throws LoadError eval(quote
-        @chain 1 (_ + 1)
-    end)
-
     # just one argument
     @test_throws LoadError eval(quote
         @chain [1, 2, 3]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,7 +80,7 @@ end
     @test y == false
 
     y = @chain 1 (==(2)) first (==(false))
-    @test y == 2
+    @test y == true
 
     y = @chain 1 (_ + 1)
     @test y == 2


### PR DESCRIPTION
Fixes #17. But I would understand if you choose not to merge it. Because we don't get a new expression on every line, we rely on Julia's parsing to make expressions, meaning we can't use binary or ternary operators, or anonymous functions. 

Nonetheless, I think it might be nice for a series of transformations on the same line. 


See the docstring I wrote for it

---

    @chain(initial_value, args...)

Rewrites a series of argments, either expressions or symbols, to feed the result
of each line into the next one. The initial value is given by the first argument.

In all arguments, underscores are replaced by the argument's result.
If there are no underscores and the argument is a symbol, the symbol is rewritten
to a function call with the previous result as the only argument.
If there are no underscores and the argument is a function call or a macrocall,
the call has the previous result prepended as the first argument.

When using this form of `@chain`, without a `begin` block, you cannot use infix
operators, binary operators, or anonymous functions. For example, `@chain 1 (_ + 2)`
will fail.

Example:

```
x = @chain [1, 2, 3] filter(!=(2), _) sqrt.(_) sum

x == sum(sqrt.(filter(!=(2), [1, 2, 3])))
```