### PR TITLE
Add a macro-flag to run chain in global scope

### DIFF
--- a/src/Chain.jl
+++ b/src/Chain.jl
@@ -5,7 +5,7 @@ export @chain
 is_aside(x) = false
 is_aside(x::Expr) = x.head == :macrocall && x.args[1] == Symbol("@aside")
 
-function fix_outer_block(x::Expr)
+function fix_outer_block(block::Expr)
     if block.head === :macrocall && block.args[1] === Symbol("@outer")
         block.args[3], true
     else


### PR DESCRIPTION
When debugging, it's often nice to be able to see intermediate inputs.

Because `@chain` operates inside a `let` block this is difficult. With this PR, you can add the macro-flag `@outer` at the top of your expression so that it isn't wrapped in a `let` block. 

This way, variable assignments that happen inside `@aside` block can be worked with after the expression is done. 

```
julia> @chain 1 @outer begin 
           +(2)
           @aside t = _
           *(5)
       end
15

julia> t
3
```

This PR is related to https://github.com/jkrumbiegel/Chain.jl/issues/33 . 

I'm not wedded to the idea. I think there is room for more design thinking about how to make things inside `@chain` blocks interactive. 