### PR TITLE
empty do chain syntax

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -477,4 +477,16 @@ end
         _ + 1
         sqrt
     end
+
+    @test ["ho", "word"] == @chain begin
+        ["hello", "world"]
+        @chain map() do
+            collect
+            @chain filter() do
+                uppercase
+                _ ∉ ('E', 'L')
+            end
+            String
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -444,6 +444,12 @@ end
 end
 
 @testset "empty do syntax" begin
+
+    @test [4, 6, 8] == @chain map(1:3) do
+        _ + 1
+        _ * 2
+    end
+
     x = @chain 1:5 begin
             @chain filter() do
                 _ + 1
@@ -467,7 +473,7 @@ end
         end
     end
 
-    @test sum(sqrt.((1:10) .+ 1)) == @chain 1:10 mapreduce(+, _) do
+    @test sum(sqrt.((1:10) .+ 1)) == @chain mapreduce(+, 1:10) do
         _ + 1
         sqrt
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -442,3 +442,33 @@ end
         @chain _ sum _ ^ 2
     end
 end
+
+@testset "empty do syntax" begin
+    x = @chain 1:5 begin
+            @chain filter() do
+                _ + 1
+                isodd
+            end
+            @chain map() do
+                _ + 2
+                sqrt
+            end
+        end
+    @test x == sqrt.([2, 4] .+ 2)
+
+    @test [[["ax", "by"]], [["cz"]]] == @chain " ax by \n cz " begin
+        split("\n")
+        @chain map() do
+            split("|")
+            @chain map() do
+                strip
+                split
+            end
+        end
+    end
+
+    @test sum(sqrt.((1:10) .+ 1)) == @chain 1:10 mapreduce(+, _) do
+        _ + 1
+        sqrt
+    end
+end


### PR DESCRIPTION
Allows this

```julia
@chain begin
    ["hello", "world"]
    @chain map() do
        collect
        @chain filter() do
            uppercase
            _ ∉ ('E', 'L')
        end
        String
    end
end
```

instead of this

```julia
@chain begin
    ["hello", "world"]
    map(_) do x
        @chain x begin
            collect
            filter(_) do y
                @chain y begin
                    uppercase
                    _ ∉ ('E', 'L')
                end
            end
            String
        end
    end
end
```