### PR TITLE
Test against correct result

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -353,7 +353,7 @@ end
         LocalModule.SubModule.power(pow)
         Base.sum
     end
-    @test y == sum(LocalModule.SubModule.power(LocalModule.SubModule.square(xs), pow))
+    @test y2 == sum(LocalModule.SubModule.power(LocalModule.SubModule.square(xs), pow))
 
     y3 = @chain xs begin
         @. LocalModule.add_one


### PR DESCRIPTION
Test case uses wrong value to compare (`y1` when it should check against `y2`). It doesn't fail as the result is the expected value but the test is worthless as it is written.