### PR TITLE
Use begin block and allow variable export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# v0.5
+
+**Breaking**: The `@chain` macro now creates a `begin` block, not a `let` block.
+This means that variables that are assigned within the macro are available outside.
+Technically, situations are imaginable where this could lead to overwritten variables if someone used large expressions with intermediate variable names in begin blocks spliced into the chain.
+It is however quite unlikely for the normal way that `@chain` is intended to be used.
+
+Additionally, it is now possible to use the syntax `variable = some_expression` to make use of the feature that variables can be exported.
+The `some_expression` part is handled exactly like before.
+This enables you to carry parts of a computation forward to a later step in the chain or outside of it:
+
+```julia
+@chain df begin
+    transform(...)
+    select(...)
+    intermediate = subset(...)
+    groupby(...)
+    combine(...)
+    join(intermediate)
+end
+
+@show intermediate
+```

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Chain"
 uuid = "8be319e6-bccf-4806-a6f7-6fae938471bc"
 authors = ["Julius Krumbiegel"]
-version = "0.4.10"
+version = "0.5.0"
 
 [compat]
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ result = @chain df begin
 end
 ```
 
-The pipeless block is equivalent to this:
+The chain block is equivalent to this:
 
 ```julia
-result = let
-    var1 = dropmissing(df)
-    var2 = filter(r -> r.weight < 6, var1)
-    var3 = groupby(var2, :group)
-    var4 = combine(var3, :weight => sum => :total_weight)
+result = begin
+    local var"##1" = dropmissing(df)
+    local var"##2" = filter(r -> r.weight < 6, var"##1")
+    local var"##3" = groupby(var"##2", :group)
+    local var"##4" = combine(var"##3", :weight => sum => :total_weight)
 end
 ```
 
@@ -151,6 +151,21 @@ This works well for short sequences that are still easy to parse visually withou
 @chain 1:10 filter(isodd, _) sum sqrt
 ```
 
+## Variable assignments in the chain
+
+You can prefix any of the expressions that Chain.jl can handle with a variable assignment.
+The previous value will be spliced into the right-hand-side expression and the result will be available afterwards under the chosen variable name.
+
+```julia
+@chain 1:10 begin
+    _ * 3
+    filtered = filter(iseven, _)
+    sum
+end
+
+filtered == [6, 12, 18, 24, 30]
+```
+
 ## The `@aside` macro
 
 For debugging, it's often useful to look at values in the middle of a pipeline.
@@ -172,12 +187,12 @@ end
 Which is again equivalent to this:
 
 ```julia
-result = let
-    var1 = dropmissing(df)
-    var2 = filter(r -> r.weight < 6, var1)
-    var3 = groupby(var2, :group)
-    println("There are $(length(var3)) groups after step 3.")
-    var4 = combine(var3, :weight => sum => :total_weight)
+result = begin
+    local var"##1" = dropmissing(df)
+    local var"##2" = filter(r -> r.weight < 6, var"##1")
+    local var"##3" = groupby(var"##2", :group)
+    println("There are $(length(var"##3")) groups after step 3.")
+    local var"##4" = combine(var"##3", :weight => sum => :total_weight)
 end
 ```
 

--- a/src/Chain.jl
+++ b/src/Chain.jl
@@ -104,7 +104,7 @@ function rewrite(expr, replacement)
             new_expr = insert_first_arg(new_expr, replacement)
         end
         replacement = gensym()
-        new_expr = Expr(Symbol("="), replacement, new_expr)
+        new_expr = :(local $replacement = $new_expr)
     end
 
     (new_expr, replacement)
@@ -198,7 +198,7 @@ function rewrite_chain_block(block)
         push!(rewritten_exprs, rewritten)
     end
 
-    result = Expr(:let, Expr(:block), Expr(:block, rewritten_exprs..., replacement))
+    result = Expr(:block, rewritten_exprs..., replacement)
 
     :($(esc(result)))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -109,15 +109,6 @@ end
             sum
         end
     end)
-
-    # variable defined in chain block doesn't leak out
-    z = @chain [1, 2, 3] begin
-        @aside inside_var = 5
-        @aside @test inside_var == 5
-        sum(_) + inside_var
-    end
-    @test z == 11
-    @test_throws UndefVarError inside_var
 end
 
 @testset "nested chains" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -436,13 +436,13 @@ end
 
 @testset "variable assignment syntax" begin
     result = @chain 1:10 begin
-        x = first(5)
+        x = filter(iseven, _)
         y = sum
         sqrt
     end
-    @test result == sqrt(sum(1:5))
-    @test x == first(1:10, 5)
-    @test y == sum(first(1:10, 5))
+    @test x == filter(iseven, 1:10)
+    @test y == sum(x)
+    @test result == sqrt(y)
 end
 
 module TestModule

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -442,3 +442,16 @@ end
         @chain _ sum _ ^ 2
     end
 end
+
+@testset "variable assignment syntax" begin
+    result = @chain 1:10 begin
+        x = first(5)
+        y = sum
+        sqrt
+    end
+    @test result == sqrt(sum(1:50))
+    @test x == first(1:10, 5)
+    @test y == sum(first(1:10, 5))
+end
+
+


### PR DESCRIPTION
**Breaking**: The `@chain` macro now creates a `begin` block, not a `let` block.
This means that variables that are assigned within the macro are available outside.
Technically, situations are imaginable where this could lead to overwritten variables if someone used large expressions with intermediate variable names in begin blocks spliced into the chain.
It is however quite unlikely for the normal way that `@chain` is intended to be used.

Additionally, it is now possible to use the syntax `variable = some_expression` to make use of the feature that variables can be exported.
The `some_expression` part is handled exactly like before.
This enables you to carry parts of a computation forward to a later step in the chain or outside of it:

```julia
@chain df begin
    transform(...)
    select(...)
    intermediate = subset(...)
    groupby(...)
    combine(...)
    join(intermediate)
end

@show intermediate
```